### PR TITLE
update game controller to take shared pointer

### DIFF
--- a/include/GameModel.h
+++ b/include/GameModel.h
@@ -34,7 +34,7 @@ namespace GameBackend
             // Used to map int values to the GameNode they represent
             std::map<int, GameNode> available_game_nodes;
 
-            std::vector<EnemyAgent*> enemyAgents;
+            std::shared_ptr<std::vector<GameBackend::EnemyAgent>> enemyAgents;
 
             // Not currently impleted
             void updateMapValue(int row, int col, int val);
@@ -46,7 +46,8 @@ namespace GameBackend
             int map2DTo1D(int row, int col);
 
         public:
-            GameModel(int x, int y, std::function<void(std::vector<int>&, int, int)> generateMap);
+            GameModel(int x, int y, std::function<void(std::vector<int>&, int, int)> generateMap, 
+                      std::shared_ptr<std::vector<GameBackend::EnemyAgent>> enemyAgents);
 
             // There should only be one game model, we don't want to allow it to be copied
             GameModel(const GameModel& gameModel) = delete;
@@ -57,11 +58,7 @@ namespace GameBackend
             void getMapDimensions(int&, int&);
             
             int getValue(int row, int col);
-
-            // Used by GameController to provide initialised enemy agents
-            // Used at the start, or can be used to provide any additional agents created throughout the program life cycle...
-            void receiveEnemyAgentsReference(std::vector<EnemyAgent*>& enemyAgents);
-
+            
             // Returns whether enemy can spawn or move to a position i.e is not blocked or lava
             // Does not care if an enemy player is currently there. Game controller will handle these interactions.
             bool isEnemyPositionValid(int xpos, int ypos);

--- a/src/GameController.cpp
+++ b/src/GameController.cpp
@@ -31,8 +31,6 @@ namespace GameBackend
             it.updatePosition(startingXPos, startingYPos);        
         }
 
-        // GameController::gameModel.get()->receiveEnemyAgentsReference(GameController::enemyAgents);
-
         deleteAgent(GameController::enemyAgents.get()->at(0).getUniqueId());
 
         // For debugging

--- a/src/GameModel.cpp
+++ b/src/GameModel.cpp
@@ -1,18 +1,17 @@
 #include "GameModel.h"
 
 #include <iostream>
-#include <exception>
-#include <string>
-#include <sstream>
 #include <cmath>
 #include <set>
+#include <utility>
 
 namespace GameBackend 
 {
     /**
      * Takes total rows and cols starting from 1
      */
-    GameModel::GameModel(int rows, int cols, std::function<void(std::vector<int>&, int, int)> generateMap) : rows(rows), cols(cols), size(rows * cols) {
+    GameModel::GameModel(int rows, int cols, std::function<void(std::vector<int>&, int, int)> generateMap, 
+    std::shared_ptr<std::vector<GameBackend::EnemyAgent>> enemyAgents) : rows(rows), cols(cols), size(rows * cols), enemyAgents(std::move(enemyAgents)) {
     
         // Generate the game nodes
         for (int i=0; i<AVAILABLE_NODES; i++) {
@@ -40,11 +39,11 @@ namespace GameBackend
 
         // Temporarily display enemy agents on map for debugging, later will need to improve this..
         std::set<int> enemyAgentsPositions;
-        bool enemyAgentsProvided = !enemyAgents.empty();
+        bool enemyAgentsProvided = !enemyAgents.get()->empty();
         if (enemyAgentsProvided) {
-            for (auto enemyAgent : enemyAgents) {
+            for (auto& enemyAgent : *enemyAgents.get()) {
                 int x, y;
-                enemyAgent->getCurrentPosition(x, y);
+                enemyAgent.getCurrentPosition(x, y);
                 enemyAgentsPositions.insert(map2DTo1D(y, x));
             }
         }
@@ -89,10 +88,6 @@ namespace GameBackend
     void GameModel::getMapDimensions(int& r, int& c) {
         r = rows;
         c = cols;
-    }
-
-    void GameModel::receiveEnemyAgentsReference(std::vector<EnemyAgent*>& enemyAgents) {
-        GameModel::enemyAgents = enemyAgents;
     }
 
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -20,14 +20,16 @@ int main() {
 	const int rows = 10;
 	const int cols = 10;
 	
-	std::unique_ptr<GameBackend::GameModel> gameModelPtr = std::make_unique<GameBackend::GameModel>(rows, cols, GameBackend::easyMapGenerator());
-	
+	// Create the agents container. Game Controller will update this, GameModel will use this to update the UI
+
 	std::shared_ptr<std::vector<GameBackend::EnemyAgent>> enemyAgents = std::make_shared<std::vector<GameBackend::EnemyAgent>>();
-	// Create the agents
 	for (int i=0; i<STARTING_ENEMIES_DEFAULT; i++) {
 		GameBackend::EnemyAgent agent;
 		enemyAgents.get()->push_back(agent);
 	}	
+
+	// Provide the agents to the controller and the model
+	std::unique_ptr<GameBackend::GameModel> gameModelPtr = std::make_unique<GameBackend::GameModel>(rows, cols, GameBackend::easyMapGenerator(), enemyAgents);
 
 	GameBackend::GameController gameController(enemyAgents, std::move(gameModelPtr));
 


### PR DESCRIPTION
Using a shared pointer to a container of static objects is advantageous
in that:

If the container is updated, all entities that have a reference/own the
shared pointer see that container with the update.

We can delete static objects (EnemyAgents) off the container itself as
although the container is a dynamic vector, the values inside the
container are static objects.